### PR TITLE
fix: add vite and vue-i18n as peerDependencies

### DIFF
--- a/packages/bundle-utils/package.json
+++ b/packages/bundle-utils/package.json
@@ -9,6 +9,18 @@
   "bugs": {
     "url": "https://github.com/intlify/bundle-tools/issues"
   },
+  "peerDependencies": {
+    "vue-i18n": "^9.0.0",
+    "petite-vue-i18n": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vue-i18n": {
+      "optional": true
+    },
+    "petite-vue-i18n": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@intlify/message-compiler": "beta",
     "@intlify/shared": "beta",

--- a/packages/vite-plugin-vue-i18n/package.json
+++ b/packages/vite-plugin-vue-i18n/package.json
@@ -9,6 +9,10 @@
   "bugs": {
     "url": "https://github.com/intlify/bundle-tools/issues"
   },
+  "peerDependencies": {
+    "vite": "^2.0.0",
+    "vue-i18n": "^9.0.0",
+  },
   "dependencies": {
     "@intlify/bundle-utils": "next",
     "@intlify/shared": "beta",

--- a/packages/vite-plugin-vue-i18n/package.json
+++ b/packages/vite-plugin-vue-i18n/package.json
@@ -12,6 +12,15 @@
   "peerDependencies": {
     "vite": "^2.0.0",
     "vue-i18n": "^9.0.0",
+    "petite-vue-i18n": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vue-i18n": {
+      "optional": true
+    },
+    "petite-vue-i18n": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@intlify/bundle-utils": "next",


### PR DESCRIPTION
The vite plugin uses vite API and require `vue-i18n` to detect which package to use. It makes sense to add them as peerDependencies and will otherwise fail with strict package manager like yarn pnp