### PR TITLE
fix: use all globs from vue-i18n include array

### DIFF
--- a/packages/vite-plugin-vue-i18n/src/index.ts
+++ b/packages/vite-plugin-vue-i18n/src/index.ts
@@ -193,8 +193,9 @@ function pluginI18n(
         let resourcePaths = [] as string[]
         const includePaths = isArray(include) ? include : [include]
         for (const inc of includePaths) {
-          resourcePaths = [...(await fg(inc))]
+          resourcePaths = [...resourcePaths, ...(await fg(inc))]
         }
+        resourcePaths = resourcePaths.filter((el, pos) => resourcePaths.indexOf(el) === pos)
         const code = await generateBundleResources(
           resourcePaths,
           isProduction,

--- a/packages/vite-plugin-vue-i18n/src/index.ts
+++ b/packages/vite-plugin-vue-i18n/src/index.ts
@@ -195,7 +195,9 @@ function pluginI18n(
         for (const inc of includePaths) {
           resourcePaths = [...resourcePaths, ...(await fg(inc))]
         }
-        resourcePaths = resourcePaths.filter((el, pos) => resourcePaths.indexOf(el) === pos)
+        resourcePaths = resourcePaths.filter(
+          (el, pos) => resourcePaths.indexOf(el) === pos
+        )
         const code = await generateBundleResources(
           resourcePaths,
           isProduction,


### PR DESCRIPTION
Vite vue-i18n plugin offers `include` config option that accepts a dir or list of dirs to bundle messages.
If an array of patterns is passed, only the last entry files were used because fast-glob results were overwritten.