### PR TITLE
perf(vite-plugin): skip transformation for unmodified code

### DIFF
--- a/packages/vite-plugin-vue-i18n/test/__snapshots__/sourcemap.test.ts.snap
+++ b/packages/vite-plugin-vue-i18n/test/__snapshots__/sourcemap.test.ts.snap
@@ -8,7 +8,7 @@ exports[`custom blocks yaml 1`] = `";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAGA,IAAI,
 
 exports[`custom blocks yml 1`] = `";;;;;;;;;;;;;;;;;;;;AAGA,IAAI,OAAO,WAAW,aAAa;SAC1B,SAASA;SACT,UAAU;AAAA;"`;
 
-exports[`resource files json 1`] = `";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAGA,IAAI,OAAO,WAAW,aAAa;SAC1B,SAAS;SACT,UAAU;AAAA;"`;
+exports[`resource files json 1`] = `";;;2EACYA,gDAAAC;;;;;wBAEAC;;;;;;;;;;;;;;;;;;;;;;ACAZ,IAAI,OAAO,WAAW,aAAa;SAC1B,SAAS;SACT,UAAU;AAAA;"`;
 
 exports[`resource files json5 1`] = `";;;;;;;;;;;AAGA,IAAI,OAAO,WAAW,aAAa;SAC1B,SAAS;SACT,UAAU;AAAA;"`;
 


### PR DESCRIPTION
In Vite's transformation hook, returning nullish value will tell Vite to bypass this tranformation, which saves the cost of handling changes and source map processing.