### PR TITLE
fix(vite-plugin-vue-i18n): use correct id in hmr

### DIFF
--- a/packages/vite-plugin-vue-i18n/src/index.ts
+++ b/packages/vite-plugin-vue-i18n/src/index.ts
@@ -210,7 +210,9 @@ function pluginI18n(
     async handleHotUpdate({ file, server }) {
       if (/\.(json5?|ya?ml)$/.test(file)) {
         const module = server.moduleGraph.getModuleById(
-          INTLIFY_BUNDLE_IMPORT_ID
+          getVirtualId(
+            INTLIFY_BUNDLE_IMPORT_ID
+          )
         )
         if (module) {
           server.moduleGraph.invalidateModule(module)

--- a/packages/vite-plugin-vue-i18n/src/index.ts
+++ b/packages/vite-plugin-vue-i18n/src/index.ts
@@ -210,9 +210,7 @@ function pluginI18n(
     async handleHotUpdate({ file, server }) {
       if (/\.(json5?|ya?ml)$/.test(file)) {
         const module = server.moduleGraph.getModuleById(
-          getVirtualId(
-            INTLIFY_BUNDLE_IMPORT_ID
-          )
+          asVirtualId(INTLIFY_BUNDLE_IMPORT_ID)
         )
         if (module) {
           server.moduleGraph.invalidateModule(module)


### PR DESCRIPTION
fixes #153 

I haven't tested this, as I currently don't have access to my computer, nor github codespaces.