### PR TITLE
feat!: support getVueI18nVersion API

### DIFF
--- a/packages/bundle-utils/src/deps.ts
+++ b/packages/bundle-utils/src/deps.ts
@@ -48,7 +48,6 @@ type VueI18nVersion = '8' | '9' | 'unknown' | ''
 
 export function getVueI18nVersion(debug: Function): VueI18nVersion {
   const VueI18n = loadModule('vue-i18n', debug)
-  console.log('vue-i18n version:', VueI18n)
   if (VueI18n == null) {
     return ''
   }

--- a/packages/bundle-utils/src/deps.ts
+++ b/packages/bundle-utils/src/deps.ts
@@ -44,14 +44,21 @@ export function checkVueI18nBridgeInstallPackage(debug: Function): boolean {
   return ret
 }
 
-export function isInstalledVue2(debug: Function): boolean {
-  const vue = loadModule('vue', debug)
-  return vue != null && vue.version != null && vue.version.startsWith('2.')
-}
+type VueI18nVersion = '8' | '9' | 'unknown' | ''
 
-export function isInstalledVue3(debug: Function): boolean {
-  const vue = loadModule('vue', debug)
-  return vue != null && vue.version != null && vue.version.startsWith('3.')
+export function getVueI18nVersion(debug: Function): VueI18nVersion {
+  const VueI18n = loadModule('vue-i18n', debug)
+  console.log('vue-i18n version:', VueI18n)
+  if (VueI18n == null) {
+    return ''
+  }
+  if (VueI18n.version && VueI18n.version.startsWith('8.')) {
+    return '8'
+  }
+  if (VueI18n.VERSION && VueI18n.VERSION.startsWith('9.')) {
+    return '9'
+  }
+  return 'unknown'
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bundle-utils/src/index.ts
+++ b/packages/bundle-utils/src/index.ts
@@ -2,8 +2,7 @@ export { CodeGenOptions, CodeGenResult, DevEnv } from './codegen'
 export { generate as generateJSON } from './json'
 export { generate as generateYAML } from './yaml'
 export {
-  isInstalledVue2,
-  isInstalledVue3,
+  getVueI18nVersion,
   checkInstallPackage,
   checkVueI18nBridgeInstallPackage,
   InstalledPackage

--- a/packages/bundle-utils/test/deps.test.ts
+++ b/packages/bundle-utils/test/deps.test.ts
@@ -2,7 +2,7 @@ import {
   checkInstallPackage,
   checkVueI18nBridgeInstallPackage,
   loadModule,
-  isInstalledVue2
+  getVueI18nVersion
 } from '../src/deps'
 
 test('vue-i18n', () => {
@@ -17,6 +17,6 @@ test('loadModule', () => {
   expect(loadModule('yaml-eslint-parser', jest.fn())).not.toBe(null)
 })
 
-test('isInstalledVue2', () => {
-  expect(isInstalledVue2(jest.fn())).toBe(true)
+test('getVueI18nVersion', () => {
+  expect(getVueI18nVersion(jest.fn())).toBe('9')
 })


### PR DESCRIPTION
BREAKING: remove `isInstalledVue2` and `isInstalledVue3`, because we want to know the VueI18n version, so that's correctly than Vue version