### PR TITLE
fix: Use `defaultSFCLang` setting for src files instead of falling back to json

### DIFF
--- a/packages/unplugin-vue-i18n/src/index.ts
+++ b/packages/unplugin-vue-i18n/src/index.ts
@@ -570,7 +570,7 @@ export const unplugin = createUnplugin<PluginOptions>((options = {}, meta) => {
             langInfo = (
               query.src
                 ? query.lang === 'i18n'
-                  ? 'json'
+                  ? defaultSFCLang
                   : query.lang
                 : query.lang
             ) as Required<PluginOptions>['defaultSFCLang']


### PR DESCRIPTION
For Vue SFCs defaultSFCLang setting wasn't respected and if the block didn't have lang attribute it would fall back to json, even if it could be yaml