### PR TITLE
feat(unplugin-vue-i18n): exclude unused locales from the bundle

### DIFF
--- a/packages/bundle-utils/src/codegen.ts
+++ b/packages/bundle-utils/src/codegen.ts
@@ -47,6 +47,7 @@ export interface CodeGenOptions {
   legacy?: boolean
   bridge?: boolean
   exportESM?: boolean
+  onlyLocales?: string[]
   source?: string
   sourceMap?: boolean
   filename?: string

--- a/packages/bundle-utils/src/codegen.ts
+++ b/packages/bundle-utils/src/codegen.ts
@@ -449,3 +449,21 @@ export function generateResourceAst(
   const code = !occured ? `${friendlyJSONstringify(ast)}` : `\`${_msg}\``
   return { code, ast, map, errors }
 }
+
+export function excludeLocales({
+  messages,
+  onlyLocales
+}: {
+  messages: Record<string, unknown>
+  onlyLocales: string[]
+}) {
+  const _messages = { ...messages }
+
+  Object.keys(_messages).forEach(locale => {
+    if (!onlyLocales.includes(locale)) {
+      delete _messages[locale]
+    }
+  })
+
+  return _messages
+}

--- a/packages/bundle-utils/src/json.ts
+++ b/packages/bundle-utils/src/json.ts
@@ -12,7 +12,8 @@ import {
   createCodeGenerator,
   generateMessageFunction,
   generateResourceAst,
-  mapLinesColumns
+  mapLinesColumns,
+  excludeLocales
 } from './codegen'
 import { generateLegacyCode } from './legacy'
 import MagicString from 'magic-string'
@@ -79,15 +80,14 @@ export function generate(
   let ast = parseJSON(value, { filePath: filename })
 
   if (!locale && type === 'sfc' && onlyLocales?.length) {
-    const messages = getStaticJSONValue(ast) as any
+    const messages = getStaticJSONValue(ast) as Record<string, unknown>
 
-    Object.keys(messages).forEach(locale => {
-      if (!onlyLocales.includes(locale)) {
-        delete messages[locale]
-      }
-    })
-
-    value = JSON.stringify(messages)
+    value = JSON.stringify(
+      excludeLocales({
+        messages,
+        onlyLocales
+      })
+    )
     ast = parseJSON(value, { filePath: filename })
   }
 

--- a/packages/bundle-utils/src/yaml.ts
+++ b/packages/bundle-utils/src/yaml.ts
@@ -5,6 +5,7 @@
 import { isString, friendlyJSONstringify } from '@intlify/shared'
 import {
   createCodeGenerator,
+  excludeLocales,
   generateMessageFunction,
   generateResourceAst,
   mapLinesColumns
@@ -79,15 +80,14 @@ export function generate(
   let ast = parseYAML(value, { filePath: filename })
 
   if (!locale && type === 'sfc' && onlyLocales?.length) {
-    const messages = getStaticYAMLValue(ast) as any
+    const messages = getStaticYAMLValue(ast) as Record<string, unknown>
 
-    Object.keys(messages).forEach(locale => {
-      if (!onlyLocales.includes(locale)) {
-        delete messages[locale]
-      }
-    })
-
-    value = JSON.stringify(messages)
+    value = JSON.stringify(
+      excludeLocales({
+        messages,
+        onlyLocales
+      })
+    )
     ast = parseYAML(value, { filePath: filename })
   }
 

--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -549,6 +549,13 @@ If you enable this option, **you should check  resources in your application are
 
   This option that to use i18n custom blocks in `vue-class-component`.
 
+### `onlyLocales`
+
+- **Type:** `string | string[]`
+- **Default:** `[]`
+
+  By using it you can exclude from the bundle those localizations that are not specified in this option.
+
 ### `useVueI18nImportName` (Experimental)
 
 - **Type:** `boolean`

--- a/packages/unplugin-vue-i18n/src/index.ts
+++ b/packages/unplugin-vue-i18n/src/index.ts
@@ -54,6 +54,14 @@ export const unplugin = createUnplugin<PluginOptions>((options = {}, meta) => {
     raiseError(`This plugin is supported 'vite' and 'webpack' only`)
   }
 
+  // normalize for `options.onlyLocales`
+  let onlyLocales: string[] = []
+  if (options.onlyLocales) {
+    onlyLocales = Array.isArray(options.onlyLocales)
+      ? options.onlyLocales
+      : [options.onlyLocales]
+  }
+
   // normalize for `options.include`
   let include = options.include
   let exclude = null
@@ -328,6 +336,7 @@ export const unplugin = createUnplugin<PluginOptions>((options = {}, meta) => {
                   escapeHtml,
                   bridge,
                   jit: jitCompilation,
+                  onlyLocales,
                   exportESM: esm,
                   forceStringify
                 }
@@ -544,6 +553,7 @@ export const unplugin = createUnplugin<PluginOptions>((options = {}, meta) => {
               escapeHtml,
               bridge,
               jit: jitCompilation,
+              onlyLocales,
               exportESM: esm,
               forceStringify
             }
@@ -606,6 +616,7 @@ export const unplugin = createUnplugin<PluginOptions>((options = {}, meta) => {
               jit: jitCompilation,
               strictMessage,
               escapeHtml,
+              onlyLocales,
               exportESM: esm,
               forceStringify
             }
@@ -699,6 +710,7 @@ async function generateBundleResources(
     forceStringify = false,
     isGlobal = false,
     bridge = false,
+    onlyLocales = [],
     exportESM = true,
     strictMessage = true,
     escapeHtml = false,
@@ -708,6 +720,7 @@ async function generateBundleResources(
     forceStringify?: boolean
     isGlobal?: boolean
     bridge?: boolean
+    onlyLocales?: string[]
     exportESM?: boolean
     strictMessage?: boolean
     escapeHtml?: boolean
@@ -728,6 +741,7 @@ async function generateBundleResources(
         useClassComponent,
         bridge,
         jit,
+        onlyLocales,
         exportESM,
         strictMessage,
         escapeHtml,
@@ -806,6 +820,7 @@ function getOptions(
     forceStringify = false,
     isGlobal = false,
     bridge = false,
+    onlyLocales = [],
     exportESM = true,
     useClassComponent = false,
     allowDynamic = false,
@@ -817,6 +832,7 @@ function getOptions(
     forceStringify?: boolean
     isGlobal?: boolean
     bridge?: boolean
+    onlyLocales?: string[]
     exportESM?: boolean
     useClassComponent?: boolean
     allowDynamic?: boolean
@@ -838,6 +854,7 @@ function getOptions(
     escapeHtml,
     bridge,
     jit,
+    onlyLocales,
     exportESM,
     env: mode,
     onWarn: (msg: string): void => {

--- a/packages/unplugin-vue-i18n/src/types.ts
+++ b/packages/unplugin-vue-i18n/src/types.ts
@@ -1,6 +1,7 @@
 export type SFCLangFormat = 'json' | 'json5' | 'yml' | 'yaml'
 export interface PluginOptions {
   include?: string | string[]
+  onlyLocales?: string | string[]
   allowDynamic?: boolean
   jitCompilation?: boolean
   dropMessageCompiler?: boolean

--- a/packages/unplugin-vue-i18n/test/vite/__snapshots__/custom-block.test.ts.snap
+++ b/packages/unplugin-vue-i18n/test/vite/__snapshots__/custom-block.test.ts.snap
@@ -174,6 +174,15 @@ exports[`jitCompilation 1`] = `
 ]
 `;
 
+exports[`json: exclude locales 1`] = `
+[
+  {
+    "locale": "",
+    "resource": {},
+  },
+]
+`;
+
 exports[`json5 1`] = `
 [
   {
@@ -183,6 +192,15 @@ exports[`json5 1`] = `
         "hello": [Function],
       },
     },
+  },
+]
+`;
+
+exports[`json5: exclude locales 1`] = `
+[
+  {
+    "locale": "",
+    "resource": {},
   },
 ]
 `;
@@ -263,6 +281,23 @@ exports[`special characters 1`] = `
 `;
 
 exports[`yaml 1`] = `
+[
+  {
+    "locale": "en",
+    "resource": {
+      "hello": [Function],
+    },
+  },
+  {
+    "locale": "ja",
+    "resource": {
+      "hello": [Function],
+    },
+  },
+]
+`;
+
+exports[`yaml: exclude locales 1`] = `
 [
   {
     "locale": "en",

--- a/packages/unplugin-vue-i18n/test/vite/custom-block.test.ts
+++ b/packages/unplugin-vue-i18n/test/vite/custom-block.test.ts
@@ -9,6 +9,33 @@ test('basic', async () => {
   expect(i18n.resource.en.hello(createMessageContext())).toEqual('hello world!')
 })
 
+test('json: exclude locales', async () => {
+  const { module } = await bundleAndRun('basic.vue', bundleVite, {
+    onlyLocales: ['ja']
+  })
+  expect(module.__i18n).toMatchSnapshot()
+  const i18n = module.__i18n.pop()
+  expect(i18n.resource.en).toBeUndefined()
+})
+
+test('yaml: exclude locales', async () => {
+  const { module } = await bundleAndRun('yaml.vue', bundleVite, {
+    onlyLocales: ['ja']
+  })
+  expect(module.__i18n).toMatchSnapshot()
+  const i18n = module.__i18n.pop()
+  expect(i18n.resource.en).toBeUndefined()
+})
+
+test('json5: exclude locales', async () => {
+  const { module } = await bundleAndRun('json5.vue', bundleVite, {
+    onlyLocales: ['ja']
+  })
+  expect(module.__i18n).toMatchSnapshot()
+  const i18n = module.__i18n.pop()
+  expect(i18n.resource.en).toBeUndefined()
+})
+
 test('yaml', async () => {
   const { module } = await bundleAndRun('yaml.vue', bundleVite)
   expect(module.__i18n).toMatchSnapshot()


### PR DESCRIPTION
## Motivation

When developing projects, we use [Nuxt Layers](https://nuxt.com/docs/getting-started/layers) to reuse common components with business logic between similar projects. For one of the projects we need only English, and for the other only German. Because the bundle of both applications includes translations of both languages, the size of unused code that is loaded in the browser also increases.

## Description of changes

In this PR I added a new `onlyLocales` property to `@intlify/unplugin-vue-i18n` config. By using it you can exclude from the bundle those localizations that are not specified in the plugin settings.

For example:

```javascript
// vite.config.ts
export default defineConfig({
  plugins: [
    vueI18n({
      onlyLocales: ['ja']
    })
  ]
})
```

```vue
<template>
  <!-- App.vue -->
  <p>{{ t('hello') }}</p>
</template>

<i18n>
{
  "en": {
    "hello": "hello, world!"
  },
  "ja": {
    "hello": "こんにちは、世界！"
  }
}
</i18n>
```

As a result of the assembly, there will be no other localizations in the bundle:

```javascript
// bundle.js
export default function (Component) {
  const _Component = Component
  _Component.__i18n = _Component.__i18n || []
  _Component.__i18n.push({
    "locale": "",
    "resource": {
      "ja": {
         // body
      }
      // resources for locale "en" are not provided because "en" is not specified in vite.config.ts
    }
  })
}
```

## Tests

- All available tests passed successfully.
- Added tests for new functionality.
