### PR TITLE
Fix vueVersion warning

### DIFF
--- a/packages/unplugin-vue-i18n/src/index.ts
+++ b/packages/unplugin-vue-i18n/src/index.ts
@@ -104,7 +104,7 @@ export const unplugin = createUnplugin<PluginOptions>((options = {}, meta) => {
   const vueVersion = isString(options.vueVersion)
     ? options.vueVersion
     : undefined
-  if (!vueVersion) {
+  if (vueVersion) {
     warn(
       `'vueVersion' option is deprecated, sinece Vue 2 was EOL on 2023. that option will be removed in 4.0.`
     )


### PR DESCRIPTION
I haven't used `vueVersion` option ever, but it showed a warning on my Shell.

<img width="952" alt="image" src="https://github.com/intlify/bundle-tools/assets/28533125/9e5af6c4-15a3-4fc5-8bdd-0a6e30344a89">
