### PR TITLE
breaking: drop `useVueI18nImportName` option

### DIFF
--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -548,7 +548,7 @@ If do you will use this option, you need to enable `jitCompilation` option.
   This option that to use i18n custom blocks in `vue-class-component`.
 
   > [!IMPORTANT]
-  'useClassComponent' option is deprecated in v5.
+  `useClassComponent` option is deprecated in v5.
   This option will be supported with vue-i18n until v9 latest version.
 
 ### `onlyLocales`
@@ -567,6 +567,9 @@ If do you will use this option, you need to enable `jitCompilation` option.
 
   This option allows a smooth migration from `petite-vue-i18n` to `vue-i18n` and allows progressive enhacement.
 
+  > [!IMPORTANT]
+  `useVueI18nImportName` option is deprecated in v5.
+  This option will be supported with vue-i18n until v9 latest version.
 
 ## 📜 Changelog
 

--- a/packages/unplugin-vue-i18n/src/types.ts
+++ b/packages/unplugin-vue-i18n/src/types.ts
@@ -11,7 +11,6 @@ export interface PluginOptions {
   forceStringify?: boolean
   defaultSFCLang?: SFCLangFormat
   globalSFCScope?: boolean
-  useVueI18nImportName?: boolean
   strictMessage?: boolean
   escapeHtml?: boolean
 }

--- a/packages/unplugin-vue-i18n/src/utils.ts
+++ b/packages/unplugin-vue-i18n/src/utils.ts
@@ -1,5 +1,63 @@
-import { promises as fs } from 'fs'
+import fs from 'node:fs'
+import { promises as fsp } from 'node:fs'
+import createDebug from 'debug'
 import pc from 'picocolors'
+import module from 'node:module'
+import path from 'node:path'
+
+const SUPPORT_PACKAGES = ['vue-i18n', 'petite-vue-i18n'] as const
+
+type SupportPackage = (typeof SUPPORT_PACKAGES)[number]
+
+type InstalledPackageInfo = {
+  alias: string
+  pkg: SupportPackage
+}
+
+const _require = module.createRequire(import.meta.url)
+
+export function checkInstallPackage(
+  debug: createDebug.Debugger
+): InstalledPackageInfo {
+  const pkgInfo =
+    resolvePkgPath('vue-i18n', debug) ||
+    resolvePkgPath('petite-vue-i18n', debug)
+  if (!pkgInfo) {
+    throw new Error(
+      `requires 'vue-i18n' or 'petite-vue-i18n' to be present in the dependency tree.`
+    )
+  }
+
+  debug('installed package info:', pkgInfo)
+  return pkgInfo
+}
+
+function resolvePkgPath(
+  id: string,
+  debug: createDebug.Debugger
+): InstalledPackageInfo | null {
+  try {
+    /**
+     * NOTE:
+     *  Assuming the case of using npm alias `npm:`,
+     *  get the installed package name from `package.json`
+     */
+    const resolvedPath = _require.resolve(id)
+    const pkgPath = path.dirname(resolvedPath)
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.join(pkgPath, 'package.json'), 'utf-8')
+    ) as { name: string }
+    const pkgName: string = pkgJson.name.startsWith('vue-i18n')
+      ? 'vue-i18n'
+      : pkgJson.name.startsWith('petite-vue-i18n')
+        ? 'petite-vue-i18n'
+        : ''
+    return pkgJson ? { alias: id, pkg: pkgName as SupportPackage } : null
+  } catch (e) {
+    debug(`cannot find '${id}'`, e)
+    return null
+  }
+}
 
 export function warn(...args: unknown[]) {
   console.warn(pc.yellow(pc.bold(`[unplugin-vue-i18n] `)), ...args)
@@ -10,7 +68,7 @@ export function error(...args: unknown[]) {
 }
 
 export async function getRaw(path: string): Promise<string> {
-  return fs.readFile(path, { encoding: 'utf-8' })
+  return fsp.readFile(path, { encoding: 'utf-8' })
 }
 
 export function raiseError(message: string) {


### PR DESCRIPTION
This option is no longer needed as unplugin-vue-i18n internally analyzes the installed modules and can automatically configure `resolve.alias`