### PR TITLE
feat(unplugin-vue-i18n): allow for a custom i18n block transform hook

### DIFF
--- a/examples/vite/src/App.vue
+++ b/examples/vite/src/App.vue
@@ -9,15 +9,18 @@
   <p id="msg">{{ t('hello') }}</p>
   <p id="custom-directive" v-t="'hi'"></p>
   <Banana />
+  <Apple />
 </template>
 
 <script>
 import { useI18n } from 'vue-i18n'
+import Apple from './Apple.vue'
 import Banana from './Banana.vue'
 
 export default {
   name: 'App',
   components: {
+    Apple,
     Banana
   },
   setup() {

--- a/examples/vite/src/Apple.vue
+++ b/examples/vite/src/Apple.vue
@@ -1,0 +1,26 @@
+<template>
+  <p>{{ t('language') }}</p>
+  <p>{{ t('hello') }}</p>
+</template>
+
+<script>
+import { useI18n } from 'vue-i18n'
+
+export default {
+  name: 'Apple',
+  setup() {
+    const { t } = useI18n({
+      inheritLocale: true,
+      useScope: 'local'
+    })
+    return { t }
+  }
+}
+</script>
+
+<i18n>
+[
+  "language",
+  "hello",
+]
+</i18n>

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -3,6 +3,27 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueI18n from '../../packages/unplugin-vue-i18n/src/vite'
 
+function transformI18nBlock(source) {
+  const sourceCopy = source
+  const block = JSON.parse(
+    sourceCopy.replace(/[\n\s]/g, '').replace(/,\]$/, ']')
+  )
+  if (Array.isArray(block)) {
+    const transformedBlock = JSON.stringify({
+      en: {
+        language: 'Language',
+        hello: 'hello, world!'
+      },
+      ja: {
+        language: '言語',
+        hello: 'こんにちは、世界！'
+      }
+    })
+    return transformedBlock
+  }
+  return source
+}
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -21,7 +42,8 @@ export default defineConfig({
     vue(),
     vueI18n({
       include: path.resolve(__dirname, './src/locales/**'),
-      optimizeTranslationDirective: true
+      optimizeTranslationDirective: true,
+      transformI18nBlock: transformI18nBlock
     })
   ]
 })

--- a/examples/webpack/src/App.vue
+++ b/examples/webpack/src/App.vue
@@ -8,15 +8,18 @@
   </form>
   <p>{{ t('hello') }}</p>
   <Banana />
+  <Apple />
 </template>
 
 <script>
 import { useI18n } from 'vue-i18n'
+import Apple from './Apple.vue'
 import Banana from './Banana.vue'
 
 export default {
   name: 'App',
   components: {
+    Apple,
     Banana
   },
   setup() {

--- a/examples/webpack/src/Apple.vue
+++ b/examples/webpack/src/Apple.vue
@@ -1,0 +1,26 @@
+<template>
+  <p>{{ t('language') }}</p>
+  <p>{{ t('hello') }}</p>
+</template>
+
+<script>
+import { useI18n } from 'vue-i18n'
+
+export default {
+  name: 'Apple',
+  setup() {
+    const { t } = useI18n({
+      inheritLocale: true,
+      useScope: 'local'
+    })
+    return { t }
+  }
+}
+</script>
+
+<i18n>
+[
+  "language",
+  "hello",
+]
+</i18n>

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -2,6 +2,28 @@ const path = require('path')
 const { VueLoaderPlugin } = require('vue-loader')
 const VueI18nPlugin = require('../../packages/unplugin-vue-i18n/lib/webpack.cjs')
 
+function transformI18nBlock(source) {
+  debugger
+  const sourceCopy = source
+  const block = JSON.parse(
+    sourceCopy.replace(/[\n\s]/g, '').replace(/,\]$/, ']')
+  )
+  if (Array.isArray(block)) {
+    const transformedBlock = JSON.stringify({
+      en: {
+        language: 'Language',
+        hello: 'hello, world!'
+      },
+      ja: {
+        language: '言語',
+        hello: 'こんにちは、世界！'
+      }
+    })
+    return transformedBlock
+  }
+  return source
+}
+
 module.exports = {
   mode: 'development',
   devtool: 'source-map',
@@ -39,7 +61,8 @@ module.exports = {
   plugins: [
     new VueLoaderPlugin(),
     VueI18nPlugin({
-      include: [path.resolve(__dirname, './src/locales/**')]
+      include: [path.resolve(__dirname, './src/locales/**')],
+      transformI18nBlock: transformI18nBlock
     })
   ]
 }

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -3,7 +3,6 @@ const { VueLoaderPlugin } = require('vue-loader')
 const VueI18nPlugin = require('../../packages/unplugin-vue-i18n/lib/webpack.cjs')
 
 function transformI18nBlock(source) {
-  debugger
   const sourceCopy = source
   const block = JSON.parse(
     sourceCopy.replace(/[\n\s]/g, '').replace(/,\]$/, ']')

--- a/packages/bundle-utils/src/codegen.ts
+++ b/packages/bundle-utils/src/codegen.ts
@@ -61,6 +61,7 @@ export interface CodeGenOptions {
   escapeHtml?: boolean
   jit?: boolean
   minify?: boolean
+  transformI18nBlock?: (source: string | Buffer) => string
   onWarn?: (msg: string) => void
   onError?: (
     msg: string,

--- a/packages/bundle-utils/src/json.ts
+++ b/packages/bundle-utils/src/json.ts
@@ -40,7 +40,8 @@ export function generate(
     onError = undefined,
     strictMessage = true,
     escapeHtml = false,
-    jit = false
+    jit = false,
+    transformI18nBlock = undefined
   }: CodeGenOptions
 ): CodeGenResult<JSONProgram> {
   let value = Buffer.isBuffer(targetSource)
@@ -63,9 +64,13 @@ export function generate(
     onError,
     strictMessage,
     escapeHtml,
-    jit
+    jit,
+    transformI18nBlock
   } as CodeGenOptions
 
+  if (transformI18nBlock) {
+    transformI18nBlock(value)
+  }
   let ast = parseJSON(value, { filePath: filename })
 
   if (!locale && type === 'sfc' && onlyLocales?.length) {

--- a/packages/bundle-utils/src/json.ts
+++ b/packages/bundle-utils/src/json.ts
@@ -40,8 +40,7 @@ export function generate(
     onError = undefined,
     strictMessage = true,
     escapeHtml = false,
-    jit = false,
-    transformI18nBlock = undefined
+    jit = false
   }: CodeGenOptions
 ): CodeGenResult<JSONProgram> {
   let value = Buffer.isBuffer(targetSource)

--- a/packages/bundle-utils/src/json.ts
+++ b/packages/bundle-utils/src/json.ts
@@ -64,13 +64,9 @@ export function generate(
     onError,
     strictMessage,
     escapeHtml,
-    jit,
-    transformI18nBlock
+    jit
   } as CodeGenOptions
 
-  if (transformI18nBlock) {
-    transformI18nBlock(value)
-  }
   let ast = parseJSON(value, { filePath: filename })
 
   if (!locale && type === 'sfc' && onlyLocales?.length) {

--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -583,6 +583,53 @@ If do you will use this option, you need to enable `jitCompilation` option.
   > [!WARNING]
   About for manually signature, see the details [vue-i18n-extensions API docs](https://github.com/intlify/vue-i18n-extensions/blob/next/docs/%40intlify/vue-i18n-extensions-api.md#translationsignatures) and [usecase from vue-i18n-extensions PR](https://github.com/intlify/vue-i18n-extensions/pull/217/files#diff-3fb9543f91e011d4b0dc9beff44082fe1a99c9eab70c1afab23c3c34352b7c38R121-R200)
 
+### `transformI18nBlock`
+
+- **Type**: `function`
+- **Default:** `undefined`
+
+  This hook allows a user to modify the `<i18n>` block before the plugin generates the translations. The hook is passed the source of the `<ii8n>` block as a `string` after the SFC is read from disk.
+
+  **Plugin**
+  ```javascript
+  function transformI18nBlock(source) {
+    // transformation logic
+  }
+
+  // Plugin
+  vueI18n({
+    transformI18nBlock
+  })
+  ```
+
+  **Before**
+  ```html
+  <i18n>
+  [
+      'slug-one',
+      'slug-two'
+  ]
+  <i18n>
+  ```
+
+  **After**
+  ```html
+  <i18n>
+  {
+      'en': {
+        'slug-one': 'foo',
+        'slug-two': 'bar'
+      },
+      ja: {
+        'slug-one': 'foo',
+        'slug-two': 'bar'
+      }
+  }
+  </i18n>
+  ```
+  > [!IMPORTANT]
+  The function **must** return a string or the build will fail.
+
 ## 📜 Changelog
 
 Details changes for each release are documented in the [CHANGELOG.md](https://github.com/intlify/bundle-tools/blob/main/packages/unplugin-vue-i18n/CHANGELOG.md)

--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -77,6 +77,11 @@ export function resolveOptions(
     TranslationDirectiveResolveIndetifier
   >()
 
+  const transformI18nBlock =
+    typeof options.transformI18nBlock === 'function'
+      ? options.transformI18nBlock
+      : null
+
   return {
     include,
     exclude,
@@ -93,7 +98,8 @@ export function resolveOptions(
     strictMessage,
     escapeHtml,
     optimizeTranslationDirective,
-    translationIdentifiers
+    translationIdentifiers,
+    transformI18nBlock
   }
 }
 

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -530,7 +530,7 @@ async function generateBundleResources(
     strictMessage = true,
     escapeHtml = false,
     jit = true,
-    transformI18nBlock = null
+    transformI18nBlock = undefined
   }: {
     forceStringify?: boolean
     isGlobal?: boolean
@@ -549,7 +549,6 @@ async function generateBundleResources(
       const { ext, name } = parsePath(res)
       const source = await getRaw(res)
       const generate = /json5?/.test(ext) ? generateJSON : generateYAML
-      debugger
       const parseOptions = getOptions(res, isProduction, {}, false, {
         isGlobal,
         jit,

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -60,7 +60,8 @@ export function resourcePlugin(
     ssrBuild,
     strictMessage,
     allowDynamic,
-    escapeHtml
+    escapeHtml,
+    transformI18nBlock
   }: ResolvedOptions,
   meta: UnpluginContextMeta,
   installedPkgInfo: InstalledPackageInfo
@@ -437,7 +438,7 @@ export function resourcePlugin(
           ) as CodeGenOptions
           debug('parseOptions', parseOptions)
 
-          const source = await getCode(
+          let source = await getCode(
             code,
             filename,
             sourceMap,
@@ -445,6 +446,16 @@ export function resourcePlugin(
             getSfcParser(),
             meta.framework
           )
+
+          if (typeof transformI18nBlock === 'function') {
+            const modifiedSource = transformI18nBlock(source)
+            if (modifiedSource && typeof modifiedSource === 'string') {
+              source = modifiedSource
+            } else {
+              warn('transformI18nBlock should return a string')
+            }
+          }
+
           const { code: generatedCode, map } = generate(source, parseOptions)
           debug('generated code', generatedCode)
           debug('sourcemap', map, sourceMap)
@@ -518,7 +529,8 @@ async function generateBundleResources(
     onlyLocales = [],
     strictMessage = true,
     escapeHtml = false,
-    jit = true
+    jit = true,
+    transformI18nBlock = null
   }: {
     forceStringify?: boolean
     isGlobal?: boolean
@@ -526,6 +538,7 @@ async function generateBundleResources(
     strictMessage?: boolean
     escapeHtml?: boolean
     jit?: boolean
+    transformI18nBlock?: PluginOptions['transformI18nBlock']
   }
 ) {
   const codes = []
@@ -536,13 +549,15 @@ async function generateBundleResources(
       const { ext, name } = parsePath(res)
       const source = await getRaw(res)
       const generate = /json5?/.test(ext) ? generateJSON : generateYAML
+      debugger
       const parseOptions = getOptions(res, isProduction, {}, false, {
         isGlobal,
         jit,
         onlyLocales,
         strictMessage,
         escapeHtml,
-        forceStringify
+        forceStringify,
+        transformI18nBlock
       }) as CodeGenOptions
       parseOptions.type = 'bare'
       const { code } = generate(source, parseOptions)
@@ -637,7 +652,8 @@ function getOptions(
     allowDynamic = false,
     strictMessage = true,
     escapeHtml = false,
-    jit = true
+    jit = true,
+    transformI18nBlock = null
   }: {
     inSourceMap?: RawSourceMap
     forceStringify?: boolean
@@ -647,6 +663,7 @@ function getOptions(
     strictMessage?: boolean
     escapeHtml?: boolean
     jit?: boolean
+    transformI18nBlock?: PluginOptions['transformI18nBlock'] | null
   }
 ): Record<string, unknown> {
   const mode: DevEnv = isProduction ? 'production' : 'development'
@@ -662,6 +679,7 @@ function getOptions(
     jit,
     onlyLocales,
     env: mode,
+    transformI18nBlock,
     onWarn: (msg: string): void => {
       warn(`${filename} ${msg}`)
     },

--- a/packages/unplugin-vue-i18n/src/types.ts
+++ b/packages/unplugin-vue-i18n/src/types.ts
@@ -14,4 +14,5 @@ export interface PluginOptions {
   strictMessage?: boolean
   escapeHtml?: boolean
   optimizeTranslationDirective?: boolean | string | string[]
+  transformI18nBlock?: (src: string | Buffer) => string
 }


### PR DESCRIPTION
### Background

My organization has been using Vue i18n for over 6 years now and it has been invaluable to the project. We recently upgraded to Vue 3 and ran into an issue with the latest version if i18n and it's newest plugins.

Due to the size of our application we've had a custom loader that runs before the Vue i18n plugin in Webpack. This allows us at build time to fetch the translations and then replace the `<i18n>` blocks with the correct format.

### Reasoning

Due to the size of our application, we can't feasibly put all the translations into our components during development so we create the slugs and then the translations are entered into our CMS by our content team. We _could_ put translations in json files in the repo - but then it requires content folks to edit via JSON files and know how to use git etc.  The ability to edit in a CMS alongside all other content is a better DX for content teams and to make that work the plugin needs this type of async hook

Additionally, this method allows us to compartmentalize the translations in the `<i18n>` blocks and the translations are bundled with each component's respective chunk.

Example of our workflow:

**Before**
```xml
<i18n>
[
    'slug-one',
    'slug-two'
]
<i18n>
```

**After**
```xml
<i18n>
{
    'en': {
      'slug-one': 'foo',
      'slug-two': 'bar'
    },
    ja: {
      'slug-one': 'foo',
      'slug-two': 'bar'
    }
}
</i18n>
```

This PR aims to allow the plugin to accept a custom transform function that will modify the source before the plugin parses the `i18n` block.

This is only necessary because it appears we read the file from disk during build and I'm unsure on how to modify the file before it reaches the Vuei18n plugin. If there's a better way to handle this please let me know. Thanks for your consideration!

### To Do

- [x] Add unit tests
- [x] Fix failing tests
