### PR TITLE
fix(unplugin-vue-i18n): don't analyze identifiers in vue files when using `pug/jsx/tsx` languages

### DIFF
--- a/packages/unplugin-vue-i18n/src/core/directive.ts
+++ b/packages/unplugin-vue-i18n/src/core/directive.ts
@@ -44,6 +44,8 @@ export function directivePlugin({
   let vuePlugin: RollupPlugin | null = null
   let vuePluginOptions: VuePluginResolvedOptions | null = null
 
+  const excludeLangs = ['pug', 'jsx', 'tsx']
+
   return {
     name: resolveNamespace('directive'),
     enforce: 'pre',
@@ -74,19 +76,19 @@ export function directivePlugin({
     },
 
     async transform(code, id) {
-      const { filename } = parseVueRequest(id)
-
-      // lazy load vue plugin options
-      if (vuePluginOptions == null) {
-        vuePluginOptions = getVuePluginOptions(vuePlugin!)
-      }
-
       if (id.endsWith('.vue')) {
-        analyzeIdentifiers(
-          getDescriptor(filename, code, vuePluginOptions!),
-          vuePluginOptions,
-          translationIdentifiers
-        )
+        const { filename, query } = parseVueRequest(id)
+        if (!excludeLangs.includes(query.lang ?? '')) {
+          // lazy load vue plugin options
+          if (vuePluginOptions == null) {
+            vuePluginOptions = getVuePluginOptions(vuePlugin!)
+          }
+          analyzeIdentifiers(
+            getDescriptor(filename, code, vuePluginOptions),
+            vuePluginOptions,
+            translationIdentifiers
+          )
+        }
       }
 
       return {


### PR DESCRIPTION
This PR includes the following changes in the `directives` plugin:
- exclude analyze identifiers when vue files using any of the following languages: `pug`, `jsx` and `tsx` (we cannot parse those languages with `@typescript-eslint/typescript-estree`)
- adds a new `excludeLangs` array containing previous languages to allow add more when required
- small refactor for perfomance

This PR doesn't fix anything about `v-t` logic in the `directives` plugin: `v-t` cannot be used (ignored/error?)

resolves #402