### PR TITLE
feat!: move packages to ESM first

### DIFF
--- a/packages/bundle-utils/package.json
+++ b/packages/bundle-utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intlify/bundle-utils",
+  "type": "module",
   "description": "Bundle utilities for Intlify project",
   "version": "9.0.0",
   "author": {
@@ -47,7 +48,6 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
       "import": "./lib/index.mjs",
       "require": "./lib/index.cjs"
     },

--- a/packages/bundle-utils/tsconfig.json
+++ b/packages/bundle-utils/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["esnext"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/packages/unplugin-vue-i18n/build.config.ts
+++ b/packages/unplugin-vue-i18n/build.config.ts
@@ -1,4 +1,9 @@
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { defineBuildConfig } from 'unbuild'
+
+const lib = fileURLToPath(new URL('./lib', import.meta.url))
 
 export default defineBuildConfig({
   declaration: true,
@@ -24,5 +29,27 @@ export default defineBuildConfig({
   rollup: {
     emitCJS: true
   },
-  externals: ['vite', 'webpack']
+  externals: ['vite', 'webpack'],
+  hooks: {
+    'build:done': async () => {
+      await Promise.all([
+        rm(resolve(lib, 'types.cjs')),
+        rm(resolve(lib, 'types.mjs')),
+        ...['vite', 'webpack'].map(async name => {
+          for (const ext of ['d.ts', 'd.cts']) {
+            const path = resolve(lib, `${name}.${ext}`)
+            const content = await readFile(path, 'utf-8')
+            await writeFile(
+              path,
+              content.replace(
+                `export { ${name} as default };`,
+                `export = ${name};`
+              ),
+              { encoding: 'utf-8' }
+            )
+          }
+        })
+      ])
+    }
+  }
 })

--- a/packages/unplugin-vue-i18n/package.json
+++ b/packages/unplugin-vue-i18n/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@intlify/unplugin-vue-i18n",
+  "type": "module",
   "version": "5.3.1",
   "description": "unplugin for Vue I18n",
   "author": {
@@ -41,7 +42,8 @@
     "vue": "^3.4"
   },
   "devDependencies": {
-    "unbuild": "^2.0.0"
+    "unbuild": "^2.0.0",
+    "@types/node": "^20.14.8"
   },
   "engines": {
     "node": ">= 18"
@@ -67,22 +69,24 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "require": "./lib/index.cjs",
-      "import": "./lib/index.mjs"
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.cjs"
     },
     "./vite": {
-      "types": "./vite.d.ts",
-      "require": "./lib/vite.cjs",
-      "import": "./lib/vite.mjs"
+      "import": "./lib/vite.mjs",
+      "require": "./lib/vite.cjs"
     },
     "./webpack": {
-      "types": "./webpack.d.ts",
-      "require": "./lib/webpack.cjs",
-      "import": "./lib/webpack.mjs"
+      "import": "./lib/webpack.mjs",
+      "require": "./lib/webpack.cjs"
     },
     "./types": {
-      "types": "./types.d.ts"
+      "import": {
+        "types": "./lib/types.d.mts"
+      },
+      "require": {
+        "types": "./lib/types.d.cts"
+      }
     },
     "./messages": {
       "types": "./messages.d.ts"

--- a/packages/unplugin-vue-i18n/tsconfig.json
+++ b/packages/unplugin-vue-i18n/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["esnext"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
         specifier: '*'
         version: 9.13.1(vue@3.4.29(typescript@5.6.3))
     devDependencies:
+      '@types/node':
+        specifier: ^20.14.8
+        version: 20.17.6
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.6.3)
@@ -1397,6 +1400,9 @@ packages:
 
   '@types/node@20.14.5':
     resolution: {integrity: sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==}
+
+  '@types/node@20.17.6':
+    resolution: {integrity: sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5252,6 +5258,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -6498,20 +6507,20 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.3
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/debug@4.1.12':
     dependencies:
@@ -6537,7 +6546,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.3':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -6553,7 +6562,7 @@ snapshots:
 
   '@types/http-proxy@1.17.14':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/js-yaml@4.0.9': {}
 
@@ -6592,11 +6601,15 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/node@20.14.5':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@20.17.6':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4':
     optional: true
@@ -6609,7 +6622,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/resolve@1.20.2': {}
 
@@ -6620,7 +6633,7 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -6629,12 +6642,12 @@ snapshots:
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
       '@types/send': 0.17.4
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@types/source-list-map@0.1.6': {}
 
@@ -6655,13 +6668,13 @@ snapshots:
 
   '@types/webpack-sources@3.2.3':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
       '@types/source-list-map': 0.1.6
       source-map: 0.7.4
 
   '@types/webpack@4.41.38':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
       '@types/tapable': 1.0.12
       '@types/uglify-js': 3.17.5
       '@types/webpack-sources': 3.2.3
@@ -6681,7 +6694,7 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
 
   '@typescript-eslint/eslint-plugin@8.13.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.14.0(jiti@2.4.0))(typescript@5.6.3)':
     dependencies:
@@ -9042,7 +9055,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.14.5
+      '@types/node': 20.17.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11117,6 +11130,8 @@ snapshots:
       - vue-tsc
 
   undici-types@5.26.5: {}
+
+  undici-types@6.19.8: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
This PR moves `@intlify/bundle-utils` and `@intlify/unplugin-vue-i18n` to ESM first (right now CJS) fixing packages exports in both packages.

<details>
<summary>Without this PR</summary>

![imagen](https://github.com/user-attachments/assets/7128f5ab-5342-4dac-855d-3a4141974704)
_[@intlify/bundle-utils](https://arethetypeswrong.github.io/?p=%40intlify%2Fvite-plugin-vue-i18n%407.0.0)_

![imagen](https://github.com/user-attachments/assets/43ac62d9-2d89-47d8-b497-cf314bc004ac)
_[@intlify/unplugin-vue-i18n](https://arethetypeswrong.github.io/?p=%40intlify%2Funplugin-vue-i18n%405.3.1)_
</details>


<details>
<summary>With this PR</summary>

![imagen](https://github.com/user-attachments/assets/f7bc2a7c-687b-4a37-b9ce-f7d52718ac25)
_@intlify/bundle-utils_

![imagen](https://github.com/user-attachments/assets/5497c6cd-74a7-47bf-a713-f37338d42591)
_@intlify/unplugin-vue-i18n_
</details>