### PR TITLE
chore(deps): update @intlify/vue-i18n-extensions to v8.0.0

### DIFF
--- a/packages/unplugin-vue-i18n/package.json
+++ b/packages/unplugin-vue-i18n/package.json
@@ -27,7 +27,7 @@
     "@eslint-community/eslint-utils": "^4.4.0",
     "@intlify/bundle-utils": "^10.0.0",
     "@intlify/shared": "latest",
-    "@intlify/vue-i18n-extensions": "^7.0.0",
+    "@intlify/vue-i18n-extensions": "^8.0.0",
     "@rollup/pluginutils": "^5.1.0",
     "@typescript-eslint/scope-manager": "^8.13.0",
     "@typescript-eslint/typescript-estree": "^8.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: latest
         version: 10.0.4
       '@intlify/vue-i18n-extensions':
-        specifier: ^7.0.0
-        version: 7.0.0(@intlify/shared@10.0.4)(@vue/compiler-dom@3.4.29)(vue-i18n@9.13.1(vue@3.4.29(typescript@5.6.3)))(vue@3.4.29(typescript@5.6.3))
+        specifier: ^8.0.0
+        version: 8.0.0(@intlify/shared@10.0.4)(@vue/compiler-dom@3.4.29)(vue-i18n@9.13.1(vue@3.4.29(typescript@5.6.3)))(vue@3.4.29(typescript@5.6.3))
       '@rollup/pluginutils':
         specifier: ^5.1.0
         version: 5.1.0(rollup@4.24.4)
@@ -932,14 +932,14 @@ packages:
     resolution: {integrity: sha512-CcFXqLfVmWLVEWJxtE632JaRUycuA6nd7tQfutbDns8BUTlBcKhjZi+bCZUis/Ls/YJ6ioyW4xE2TYdlReutaA==}
     engines: {node: '>= 16'}
 
-  '@intlify/vue-i18n-extensions@7.0.0':
-    resolution: {integrity: sha512-MtvfJnb4aklpCU5Q/dkWkBT/vGsp3qERiPIwtTq5lX4PCLHtUprAJZp8wQj5ZcwDaFCU7+yVMjYbeXpIf927cA==}
+  '@intlify/vue-i18n-extensions@8.0.0':
+    resolution: {integrity: sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==}
     engines: {node: '>= 18'}
     peerDependencies:
-      '@intlify/shared': ^9.0.0 || ^10.0.0
+      '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
       '@vue/compiler-dom': ^3.0.0
       vue: ^3.0.0
-      vue-i18n: ^9.0.0 || ^10.0.0
+      vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
     peerDependenciesMeta:
       '@intlify/shared':
         optional: true
@@ -6197,7 +6197,7 @@ snapshots:
       '@intlify/core-base': 9.13.1
       '@intlify/shared': 9.13.1
 
-  '@intlify/vue-i18n-extensions@7.0.0(@intlify/shared@10.0.4)(@vue/compiler-dom@3.4.29)(vue-i18n@9.13.1(vue@3.4.29(typescript@5.6.3)))(vue@3.4.29(typescript@5.6.3))':
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@10.0.4)(@vue/compiler-dom@3.4.29)(vue-i18n@9.13.1(vue@3.4.29(typescript@5.6.3)))(vue@3.4.29(typescript@5.6.3))':
     dependencies:
       '@babel/parser': 7.24.7
     optionalDependencies:


### PR DESCRIPTION
### Description

Updated [@intlify/vue-i18n-extensions to v8.0.0](https://github.com/intlify/vue-i18n-extensions/releases/tag/v8.0.0) to resolve unmet peer dependencies with vue-i18n@11.0.1.

### Linked Issues

- https://github.com/intlify/bundle-tools/issues/431
