### PR TITLE
feat: virtual messages HMR for vite

### DIFF
--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -607,6 +607,15 @@ If do you will use this option, you need to enable `jitCompilation` option.
 
   By using it you can exclude from the bundle those localizations that are not specified in this option.
 
+### `hot`
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+  Enables HMR without page reload for bundled virtual messages `@intlify/unplugin-vue-i18n/messages`.
+
+  > [!IMPORTANT] > Vite support only
+
 ### `useVueI18nImportName` (Experimental)
 
 - **Type:** `boolean`

--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -610,9 +610,9 @@ If do you will use this option, you need to enable `jitCompilation` option.
 ### `hmr`
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true`
 
-  Enables HMR without page reload for bundled virtual messages `@intlify/unplugin-vue-i18n/messages`.
+  HMR without page reload for bundled virtual messages `@intlify/unplugin-vue-i18n/messages`.
 
   > [!IMPORTANT] > Vite support only
 

--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -616,6 +616,13 @@ If do you will use this option, you need to enable `jitCompilation` option.
 
   > [!IMPORTANT] > Vite support only
 
+### `appRootContainer`
+
+- **Type:** `string`
+- **Default:** `'#app'`
+
+  The selector used find the Vue app root container during HMR.
+
 ### `useVueI18nImportName` (Experimental)
 
 - **Type:** `boolean`

--- a/packages/unplugin-vue-i18n/README.md
+++ b/packages/unplugin-vue-i18n/README.md
@@ -607,7 +607,7 @@ If do you will use this option, you need to enable `jitCompilation` option.
 
   By using it you can exclude from the bundle those localizations that are not specified in this option.
 
-### `hot`
+### `hmr`
 
 - **Type:** `boolean`
 - **Default:** `false`

--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -58,6 +58,7 @@ export function resolveOptions(options: PluginOptions) {
 
   const allowDynamic = !!options.allowDynamic
   const hmr = !!options.hmr
+  const appRootContainer = options.appRootContainer ?? '#app'
 
   const strictMessage = isBoolean(options.strictMessage)
     ? options.strictMessage
@@ -85,6 +86,7 @@ export function resolveOptions(options: PluginOptions) {
     include,
     exclude,
     hmr,
+    appRootContainer,
     module: moduleType,
     onlyLocales,
     forceStringify,

--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -57,6 +57,7 @@ export function resolveOptions(options: PluginOptions) {
   const ssrBuild = !!options.ssr
 
   const allowDynamic = !!options.allowDynamic
+  const hot = !!options.hot
 
   const strictMessage = isBoolean(options.strictMessage)
     ? options.strictMessage
@@ -83,6 +84,7 @@ export function resolveOptions(options: PluginOptions) {
   return {
     include,
     exclude,
+    hot,
     module: moduleType,
     onlyLocales,
     forceStringify,

--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -57,7 +57,7 @@ export function resolveOptions(options: PluginOptions) {
   const ssrBuild = !!options.ssr
 
   const allowDynamic = !!options.allowDynamic
-  const hot = !!options.hot
+  const hmr = !!options.hmr
 
   const strictMessage = isBoolean(options.strictMessage)
     ? options.strictMessage
@@ -84,7 +84,7 @@ export function resolveOptions(options: PluginOptions) {
   return {
     include,
     exclude,
-    hot,
+    hmr,
     module: moduleType,
     onlyLocales,
     forceStringify,

--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -57,7 +57,7 @@ export function resolveOptions(options: PluginOptions) {
   const ssrBuild = !!options.ssr
 
   const allowDynamic = !!options.allowDynamic
-  const hmr = !!options.hmr
+  const hmr = options.hmr ?? true
   const appRootContainer = options.appRootContainer ?? '#app'
 
   const strictMessage = isBoolean(options.strictMessage)

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -61,7 +61,7 @@ export function resourcePlugin(
     strictMessage,
     allowDynamic,
     escapeHtml,
-    hot,
+    hmr,
     transformI18nBlock
   }: ResolvedOptions,
   meta: UnpluginContextMeta
@@ -328,7 +328,7 @@ export function resourcePlugin(
             forceStringify,
             strictMessage,
             escapeHtml,
-            hot
+            hmr
           }
         )
         // TODO: support virtual import identifier
@@ -528,7 +528,7 @@ async function generateBundleResources(
     strictMessage = true,
     escapeHtml = false,
     jit = true,
-    hot = false,
+    hmr = false,
     transformI18nBlock = undefined
   }: {
     forceStringify?: boolean
@@ -537,7 +537,7 @@ async function generateBundleResources(
     strictMessage?: boolean
     escapeHtml?: boolean
     jit?: boolean
-    hot?: boolean
+    hmr?: boolean
     transformI18nBlock?: PluginOptions['transformI18nBlock']
   }
 ) {
@@ -619,7 +619,7 @@ const merged = mergeDeep({},
 );
 export default merged
 
-${isProduction || !hot ? '' : hmrCode}
+${isProduction || !hmr ? '' : hmrCode}
 `
 }
 

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -584,7 +584,19 @@ const mergeDeep = (target, ...sources) => {
 
 export default mergeDeep({},
   ${codes.map(code => `{${code}}`).join(',\n')}
-);`
+);
+
+if(import.meta.hot) {
+  import.meta.hot.accept(mod => {
+    // retrieve global i18n instance
+    const i18n = document.querySelector('#app').__vue_app__.__VUE_I18N__.global
+
+    // set locale messages per locale
+    for(const locale in mod.default){
+      i18n.setLocaleMessage(locale, mod.default[locale])
+    }
+  })
+}`
 }
 
 async function getCode(

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -61,6 +61,7 @@ export function resourcePlugin(
     strictMessage,
     allowDynamic,
     escapeHtml,
+    hot,
     transformI18nBlock
   }: ResolvedOptions,
   meta: UnpluginContextMeta
@@ -326,7 +327,8 @@ export function resourcePlugin(
           {
             forceStringify,
             strictMessage,
-            escapeHtml
+            escapeHtml,
+            hot
           }
         )
         // TODO: support virtual import identifier
@@ -526,6 +528,7 @@ async function generateBundleResources(
     strictMessage = true,
     escapeHtml = false,
     jit = true,
+    hot = false,
     transformI18nBlock = undefined
   }: {
     forceStringify?: boolean
@@ -534,6 +537,7 @@ async function generateBundleResources(
     strictMessage?: boolean
     escapeHtml?: boolean
     jit?: boolean
+    hot?: boolean
     transformI18nBlock?: PluginOptions['transformI18nBlock']
   }
 ) {
@@ -615,7 +619,7 @@ const merged = mergeDeep({},
 );
 export default merged
 
-${isProduction ? '' : hmrCode}
+${isProduction || !hot ? '' : hmrCode}
 `
 }
 

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -51,6 +51,7 @@ export function resourcePlugin(
     exclude,
     module,
     forceStringify,
+    appRootContainer,
     defaultSFCLang,
     globalSFCScope,
     runtimeOnly,
@@ -231,6 +232,16 @@ export function resourcePlugin(
           }
         }
       },
+      configureServer(server) {
+        // client could not find vue app root during HMR
+        server.ws.on('unplugin-vue-i18n:app-root-missing', _ => {
+          console.error(
+            `[unplugin-vue-i18n] Unable to find vue-i18n instance on vue app root container with selector "${appRootContainer}" - skipping HMR and reloading page.\n` +
+              `The selector used can be configured using the \`appRootcontainer\` option.`
+          )
+          server.ws.send({ type: 'full-reload' })
+        })
+      },
 
       async handleHotUpdate({ file, server }) {
         if (/\.(json5?|ya?ml)$/.test(file)) {
@@ -328,7 +339,8 @@ export function resourcePlugin(
             forceStringify,
             strictMessage,
             escapeHtml,
-            hmr
+            hmr,
+            appRootContainer
           }
         )
         // TODO: support virtual import identifier
@@ -529,6 +541,7 @@ async function generateBundleResources(
     escapeHtml = false,
     jit = true,
     hmr = false,
+    appRootContainer,
     transformI18nBlock = undefined
   }: {
     forceStringify?: boolean
@@ -538,6 +551,7 @@ async function generateBundleResources(
     escapeHtml?: boolean
     jit?: boolean
     hmr?: boolean
+    appRootContainer: string
     transformI18nBlock?: PluginOptions['transformI18nBlock']
   }
 ) {
@@ -582,7 +596,11 @@ if(import.meta.hot) {
 
   import.meta.hot.accept(mod => {
     // retrieve global i18n instance
-    const i18n = document.querySelector('#app').__vue_app__.__VUE_I18N__.global
+    const i18n = document.querySelector('${appRootContainer}')?.__vue_app__?.__VUE_I18N__?.global
+    if(i18n == null) {
+      import.meta.hot.send('unplugin-vue-i18n:app-root-missing', {})
+      return
+    }
 
     // locale keys of both original and updated merged messages
     const localeKeys = uniqueKeys(merged, mod.default)

--- a/packages/unplugin-vue-i18n/src/index.ts
+++ b/packages/unplugin-vue-i18n/src/index.ts
@@ -29,7 +29,7 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (
   const resolvedOptions = resolveOptions(options)
   debug('plugin options (resolved):', resolvedOptions)
 
-  if (resolvedOptions.hmr && meta.framework === 'webpack') {
+  if (options.hmr && meta.framework === 'webpack') {
     warn(getWebpackNotSupportedMessage('hmr'))
   }
 

--- a/packages/unplugin-vue-i18n/src/index.ts
+++ b/packages/unplugin-vue-i18n/src/index.ts
@@ -29,8 +29,8 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (
   const resolvedOptions = resolveOptions(options)
   debug('plugin options (resolved):', resolvedOptions)
 
-  if (resolvedOptions.hot && meta.framework === 'webpack') {
-    warn(getWebpackNotSupportedMessage('hot'))
+  if (resolvedOptions.hmr && meta.framework === 'webpack') {
+    warn(getWebpackNotSupportedMessage('hmr'))
   }
 
   const plugins = [resourcePlugin(resolvedOptions, meta)]

--- a/packages/unplugin-vue-i18n/src/index.ts
+++ b/packages/unplugin-vue-i18n/src/index.ts
@@ -1,6 +1,11 @@
 import { createUnplugin } from 'unplugin'
 import createDebug from 'debug'
-import { raiseError, resolveNamespace } from './utils'
+import {
+  getWebpackNotSupportedMessage,
+  raiseError,
+  resolveNamespace,
+  warn
+} from './utils'
 import { resolveOptions, resourcePlugin, directivePlugin } from './core'
 
 import type { UnpluginFactory, UnpluginInstance } from 'unplugin'
@@ -24,13 +29,14 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (
   const resolvedOptions = resolveOptions(options)
   debug('plugin options (resolved):', resolvedOptions)
 
+  if (resolvedOptions.hot && meta.framework === 'webpack') {
+    warn(getWebpackNotSupportedMessage('hot'))
+  }
+
   const plugins = [resourcePlugin(resolvedOptions, meta)]
   if (resolvedOptions.optimizeTranslationDirective) {
     if (meta.framework === 'webpack') {
-      raiseError(
-        `The 'optimizeTranslationDirective' option still is not supported for webpack.\n` +
-          `We are waiting for your Pull Request 🙂.`
-      )
+      raiseError(getWebpackNotSupportedMessage('optimizeTranslationDirective'))
     }
     plugins.push(directivePlugin(resolvedOptions))
   }

--- a/packages/unplugin-vue-i18n/src/types.ts
+++ b/packages/unplugin-vue-i18n/src/types.ts
@@ -10,7 +10,7 @@ export interface PluginOptions {
   runtimeOnly?: boolean
   compositionOnly?: boolean
   ssr?: boolean
-  hot?: boolean
+  hmr?: boolean
   fullInstall?: boolean
   forceStringify?: boolean
   defaultSFCLang?: SFCLangFormat

--- a/packages/unplugin-vue-i18n/src/types.ts
+++ b/packages/unplugin-vue-i18n/src/types.ts
@@ -10,6 +10,7 @@ export interface PluginOptions {
   runtimeOnly?: boolean
   compositionOnly?: boolean
   ssr?: boolean
+  hot?: boolean
   fullInstall?: boolean
   forceStringify?: boolean
   defaultSFCLang?: SFCLangFormat

--- a/packages/unplugin-vue-i18n/src/types.ts
+++ b/packages/unplugin-vue-i18n/src/types.ts
@@ -11,6 +11,7 @@ export interface PluginOptions {
   compositionOnly?: boolean
   ssr?: boolean
   hmr?: boolean
+  appRootContainer?: string
   fullInstall?: boolean
   forceStringify?: boolean
   defaultSFCLang?: SFCLangFormat

--- a/packages/unplugin-vue-i18n/src/utils/log.ts
+++ b/packages/unplugin-vue-i18n/src/utils/log.ts
@@ -12,3 +12,11 @@ export function error(...args: unknown[]) {
 export function raiseError(message: string) {
   throw new Error(`[${PKG_NAME}] ${message}`)
 }
+
+// TODO: extract warn/error messages similar to vue-i18n structure
+export function getWebpackNotSupportedMessage(optionName: string) {
+  return (
+    `The '${optionName}' option still is not supported for webpack.\n` +
+    `We are waiting for your Pull Request 🙂.`
+  )
+}


### PR DESCRIPTION
I'm slowly learning more about HMR and have been working on something similar for nuxt-i18n https://github.com/nuxt-modules/i18n/pull/3363/

This is a starting point for HMR without reloading the page, so translations can be changed while app state is preserved.

This PR is incomplete:
* It assumes the Vue instance is found on an element with `#app`
* This overwrites locale messages with those exported by `@intlify/unplugin-vue-i18n/messages`, if users are merging other messages with those exported by the virtual bundle (e.g. merging objects during creation of the i18n instance) these will be lost on change.
* Untested using webpack, I'm assuming it does not work the same there without additional changes.