### PR TITLE
refactor: simplify resource logic

### DIFF
--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -5,7 +5,7 @@ import type { PluginOptions } from '../types'
 import type { TranslationDirectiveResolveIndetifier } from '../vue'
 
 export function resolveOptions(options: PluginOptions) {
-  const moduleType = (options.module || 'vue-i18n') as string
+  const moduleType = options.module || 'vue-i18n'
 
   // normalize for `options.onlyLocales`
   let onlyLocales: string[] = []


### PR DESCRIPTION
This refactor mostly changes the way options are passed around in the resource plugin, and preserves the original option names to make it easier to keep track of where the values come from.