### PR TITLE
chore(deps): replace `playwright` with `playwright-core`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,22 +118,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      # https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml#L62
-      # Install playwright's binary under custom directory to cache
-      - name: Set Playwright path
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
-
-      - name: Cache Playwright's binary
-        uses: actions/cache@v4
-        with:
-          # Playwright removes unused browsers automatically
-          # So does not need to add playwright version to key
-          key: ${{ runner.os }}-playwright-bin-v1
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-
       - name: Install Playwright
-        # does not need to explicitly set chromium after https://github.com/microsoft/playwright/issues/14862 is solved
-        run: pnpm playwright install chromium
+        run: pnpm playwright-core install chromium
 
       - name: Restore dist cache
         uses: actions/cache@v4

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright'
+import type { Page } from 'playwright-core'
 
 export async function getText(
   page: Page,

--- a/e2e/vite.spec.ts
+++ b/e2e/vite.spec.ts
@@ -2,7 +2,7 @@ import { startServer } from './setup-server'
 import { getText } from './helper'
 
 import type { ServerContext } from './setup-server'
-import type { Browser, Page } from 'playwright'
+import type { Browser, Page } from 'playwright-core'
 import { describe, expect, test, beforeAll, afterAll } from 'vitest'
 
 // TODO: extract to shim.d.ts

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "minimist": "^1.2.8",
     "npm-run-all2": "^7.0.1",
     "opener": "^1.5.2",
-    "playwright": "^1.44.0",
+    "playwright-core": "^1.51.0",
     "prettier": "^3.2.5",
     "prompts": "^2.4.2",
     "rollup": "^2.53.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,9 +125,9 @@ importers:
       opener:
         specifier: ^1.5.2
         version: 1.5.2
-      playwright:
-        specifier: ^1.44.0
-        version: 1.44.1
+      playwright-core:
+        specifier: ^1.51.0
+        version: 1.51.0
       prettier:
         specifier: ^3.2.5
         version: 3.3.2
@@ -3605,11 +3605,6 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4897,14 +4892,9 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.44.1:
-    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  playwright@1.44.1:
-    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
-    engines: {node: '>=16'}
+  playwright-core@1.51.0:
+    resolution: {integrity: sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   possible-typed-array-names@1.0.0:
@@ -9809,9 +9799,6 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
-  fsevents@2.3.2:
-    optional: true
-
   fsevents@2.3.3:
     optional: true
 
@@ -11341,13 +11328,7 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  playwright-core@1.44.1: {}
-
-  playwright@1.44.1:
-    dependencies:
-      playwright-core: 1.44.1
-    optionalDependencies:
-      fsevents: 2.3.2
+  playwright-core@1.51.0: {}
 
   possible-typed-array-names@1.0.0:
     optional: true

--- a/scripts/playwright.ts
+++ b/scripts/playwright.ts
@@ -1,9 +1,9 @@
 async function main() {
   try {
-    await import('playwright')
+    await import('playwright-core')
   } catch (e) {
     console.error(
-      'Playwright is not installed. Please run `pnpm playwright install chromium`'
+      'Playwright is not installed. Please run `pnpm playwright-core install chromium`'
     )
     throw e
   }

--- a/scripts/vitest.setup.ts
+++ b/scripts/vitest.setup.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll } from 'vitest'
-import playwright from 'playwright'
+import playwright from 'playwright-core'
 
-import type { Browser, Page, LaunchOptions } from 'playwright'
+import type { Browser, Page, LaunchOptions } from 'playwright-core'
 
 // TODO: extract to shim.d.ts
 // eslint-disable-next-line @typescript-eslint/no-namespace


### PR DESCRIPTION
This is the update path for `playwright`, also removes Playwright caching from the workflow as this is (I believe) recommended by their docs and consistent with the other i18n repository workflows.