### PR TITLE
refactor: simplify js generate

### DIFF
--- a/packages/bundle-utils/src/js.ts
+++ b/packages/bundle-utils/src/js.ts
@@ -182,9 +182,15 @@ function _generate(
   const codeMaps = new Map<string, RawSourceMap>()
   const { type, sourceMap, isGlobal, locale, jit } = options
 
-  const codegenFn: CodeGenFunction = jit
+  const _codegenFn: CodeGenFunction = jit
     ? generateResourceAst
     : generateMessageFunction
+
+  function codegenFn(value: string) {
+    const { code, map } = _codegenFn(value, options, pathStack)
+    sourceMap && map != null && codeMaps.set(value, map)
+    return code
+  }
 
   const componentNamespace = '_Component'
   const variableDeclarations: string[] = []
@@ -250,15 +256,20 @@ function _generate(
         }
       }
 
+      if (parent?.type === 'ArrayExpression') {
+        const lastIndex = itemsCountStack.length - 1
+        const currentCount = parent.elements.length - itemsCountStack[lastIndex]
+        pathStack.push(currentCount.toString())
+        itemsCountStack[lastIndex] = --itemsCountStack[lastIndex]
+      }
+
       switch (node.type) {
         case 'Program':
           if (type === 'plain') {
             generator.push(`const resource = `)
           } else if (type === 'sfc') {
-            // for 'sfc'
-            const variableName =
-              type === 'sfc' ? (!isGlobal ? '__i18n' : '__i18nGlobal') : ''
-            const localeName = type === 'sfc' ? locale ?? `""` : ''
+            const localeName = JSON.stringify(locale ?? '')
+            const variableName = !isGlobal ? '__i18n' : '__i18nGlobal'
             generator.push(`export default function (Component) {`)
             generator.indent()
             generator.pushline(`const ${componentNamespace} = Component`)
@@ -267,163 +278,108 @@ function _generate(
             )
             generator.push(`${componentNamespace}.${variableName}.push({`)
             generator.indent()
-            generator.pushline(`"locale": ${JSON.stringify(localeName)},`)
+            generator.pushline(`"locale": ${localeName},`)
             generator.push(`"resource": `)
           }
           break
         case 'ObjectExpression':
-          generator.push(`{`)
+          generator.push('{')
           generator.indent()
           propsCountStack.push(node.properties.length)
-          if (parent?.type === 'ArrayExpression') {
-            const lastIndex = itemsCountStack.length - 1
-            const currentCount =
-              parent.elements.length - itemsCountStack[lastIndex]
-            pathStack.push(currentCount.toString())
-            itemsCountStack[lastIndex] = --itemsCountStack[lastIndex]
-          }
-          break
-        case 'Property':
-          if (parent?.type === 'ObjectExpression') {
-            if (
-              isJSONablePrimitiveLiteral(node.value) &&
-              (node.key.type === 'Literal' || node.key.type === 'Identifier')
-            ) {
-              // prettier-ignore
-              const name = node.key.type === 'Literal'
-                ? String(node.key.value)
-                : node.key.name
-              if (
-                (node.value.type === 'Literal' && isString(node.value.value)) ||
-                node.value.type === 'TemplateLiteral'
-              ) {
-                const value = getValue(node.value) as string
-                generator.push(`${JSON.stringify(name)}: `)
-                pathStack.push(name)
-                const { code, map } = codegenFn(value, options, pathStack)
-                sourceMap && map != null && codeMaps.set(value, map)
-                generator.push(`${code}`, node.value, value)
-                skipStack.push(false)
-              } else {
-                const value = getValue(node.value)
-                if (forceStringify) {
-                  const strValue = JSON.stringify(value)
-                  generator.push(`${JSON.stringify(name)}: `)
-                  pathStack.push(name)
-                  const { code, map } = codegenFn(strValue, options, pathStack)
-                  sourceMap && map != null && codeMaps.set(strValue, map)
-                  generator.push(`${code}`, node.value, strValue)
-                } else {
-                  generator.push(
-                    `${JSON.stringify(name)}: ${JSON.stringify(value)}`
-                  )
-                  pathStack.push(name)
-                }
-                skipStack.push(false)
-              }
-            } else if (
-              (node.value.type === 'FunctionExpression' ||
-                node.value.type === 'ArrowFunctionExpression') &&
-              (node.key.type === 'Literal' || node.key.type === 'Identifier')
-            ) {
-              // prettier-ignore
-              const name = node.key.type === 'Literal'
-                ? String(node.key.value)
-                : node.key.name
-              generator.push(`${JSON.stringify(name)}: `)
-              pathStack.push(name)
-              const code = generateJavaScript(node.value, {
-                format: { compact: true }
-              })
-              generator.push(`${code}`, node.value, code)
-              skipStack.push(false)
-            } else if (
-              (node.value.type === 'ObjectExpression' ||
-                node.value.type === 'ArrayExpression') &&
-              (node.key.type === 'Literal' || node.key.type === 'Identifier')
-            ) {
-              // prettier-ignore
-              const name = node.key.type === 'Literal'
-                ? String(node.key.value)
-                : node.key.name
-              generator.push(`${JSON.stringify(name)}: `)
-              pathStack.push(name)
-            } else {
-              const skipProperty = 'regex' in node.value
-              if (!skipProperty && node.type === 'Property') {
-                const name =
-                  (node.key.type === 'Identifier' && String(node.key.name)) ||
-                  (node.key.type === 'Literal' && String(node.key.value))
-                const name2 =
-                  (node.value.type === 'Identifier' &&
-                    String(node.value.name)) ||
-                  (node.value.type === 'Literal' && String(node.value.value))
-
-                generator.push(`${JSON.stringify(name)}: ${name2 || name}`)
-                skipStack.push(false)
-              } else {
-                // for Regex, function, etc.
-                skipStack.push(true)
-              }
-            }
-            const lastIndex = propsCountStack.length - 1
-            propsCountStack[lastIndex] = --propsCountStack[lastIndex]
-          }
           break
         case 'ArrayExpression':
-          generator.push(`[`)
+          generator.push('[')
           generator.indent()
-          if (parent?.type === 'ArrayExpression') {
-            const lastIndex = itemsCountStack.length - 1
-            const currentCount =
-              parent.elements.length - itemsCountStack[lastIndex]
-            pathStack.push(currentCount.toString())
-            itemsCountStack[lastIndex] = --itemsCountStack[lastIndex]
-          }
           itemsCountStack.push(node.elements.length)
           break
-        case 'SpreadElement':
-          const name =
-            (node.argument.type === 'Identifier' &&
-              String(node.argument.name)) ||
-            (node.argument.type === 'Literal' && String(node.argument.value))
-          generator.push(`...${name}`)
-          break
-        default:
-          if (parent?.type === 'ArrayExpression') {
-            const lastIndex = itemsCountStack.length - 1
-            const currentCount =
-              parent.elements.length - itemsCountStack[lastIndex]
+        case 'Property':
+          if (parent?.type !== 'ObjectExpression') break
+          if (node.key.type !== 'Literal' && node.key.type !== 'Identifier')
+            break
 
-            pathStack.push(currentCount.toString())
+          // prettier-ignore
+          const name = node.key.type === 'Literal'
+            ? String(node.key.value)
+            : node.key.name
+          const strName = JSON.stringify(name)
+          if (isJSONablePrimitiveLiteral(node.value)) {
+            generator.push(`${strName}: `)
+            pathStack.push(name)
+            const value = getValue(node.value) as string
+            const strValue = JSON.stringify(value)
+            if (
+              (node.value.type === 'Literal' && isString(node.value.value)) ||
+              node.value.type === 'TemplateLiteral'
+            ) {
+              generator.push(codegenFn(value), node.value, value)
+            } else if (forceStringify) {
+              generator.push(codegenFn(strValue), node.value, strValue)
+            } else {
+              generator.push(strValue)
+            }
+            skipStack.push(false)
+          } else if (
+            node.value.type === 'ArrayExpression' ||
+            node.value.type === 'ObjectExpression'
+          ) {
+            generator.push(`${strName}: `)
+            pathStack.push(name)
+            skipStack.push(false)
+          } else if (
+            node.value.type === 'FunctionExpression' ||
+            node.value.type === 'ArrowFunctionExpression'
+          ) {
+            generator.push(`${strName}: `)
+            pathStack.push(name)
+            const code = generateJavaScript(node.value, {
+              format: { compact: true }
+            })
+            generator.push(code, node.value, code)
+            skipStack.push(false)
+          } else {
+            const skipProperty = 'regex' in node.value
+            if (!skipProperty && node.type === 'Property') {
+              const identifierName =
+                (node.value.type === 'Identifier' && String(node.value.name)) ||
+                (node.value.type === 'Literal' && String(node.value.value))
 
-            if (isJSONablePrimitiveLiteral(node)) {
-              if (
-                (node.type === 'Literal' && isString(node.value)) ||
-                node.type === 'TemplateLiteral'
-              ) {
-                const value = getValue(node) as string
-                const { code, map } = codegenFn(value, options, pathStack)
-                sourceMap && map != null && codeMaps.set(value, map)
-                generator.push(`${code}`, node, value)
-              } else {
-                const value = getValue(node)
-                if (forceStringify) {
-                  const strValue = JSON.stringify(value)
-                  const { code, map } = codegenFn(strValue, options, pathStack)
-                  sourceMap && map != null && codeMaps.set(strValue, map)
-                  generator.push(`${code}`, node, strValue)
-                } else {
-                  generator.push(`${JSON.stringify(value)}`)
-                }
-              }
-
+              generator.push(`${strName}: ${identifierName || name}`)
               skipStack.push(false)
             } else {
               // for Regex, function, etc.
               skipStack.push(true)
             }
-            itemsCountStack[lastIndex] = --itemsCountStack[lastIndex]
+          }
+          const lastIndex = propsCountStack.length - 1
+          propsCountStack[lastIndex] = --propsCountStack[lastIndex]
+          break
+        case 'SpreadElement':
+          const spreadIdentifier =
+            (node.argument.type === 'Identifier' &&
+              String(node.argument.name)) ||
+            (node.argument.type === 'Literal' && String(node.argument.value))
+          generator.push(`...${spreadIdentifier}`)
+          break
+        default:
+          if (parent?.type === 'ArrayExpression') {
+            if (isJSONablePrimitiveLiteral(node)) {
+              const value = getValue(node) as string
+              const strValue = JSON.stringify(value)
+              if (
+                (node.type === 'Literal' && isString(node.value)) ||
+                node.type === 'TemplateLiteral'
+              ) {
+                generator.push(codegenFn(value), node, value)
+              } else if (forceStringify) {
+                generator.push(codegenFn(strValue), node, strValue)
+              } else {
+                generator.push(strValue)
+              }
+              skipStack.push(false)
+            } else {
+              // for Regex, function, etc.
+              skipStack.push(true)
+            }
           }
           break
       }
@@ -438,14 +394,14 @@ function _generate(
     leave(node: Node, parent: Node) {
       switch (node.type) {
         case 'Program':
-          if (type === 'sfc') {
-            generator.deindent()
-            generator.push(`})`)
-            generator.deindent()
-            generator.pushline(`}`)
-          } else if (type === 'plain') {
-            generator.push(`\n`)
+          if (type === 'plain') {
+            generator.push('\n')
             generator.push('export default resource')
+          } else if (type === 'sfc') {
+            generator.deindent()
+            generator.push('})')
+            generator.deindent()
+            generator.pushline('}')
           }
           break
         case 'ObjectExpression':
@@ -454,25 +410,7 @@ function _generate(
             propsCountStack.pop()
           }
           generator.deindent()
-          generator.push(`}`)
-          if (parent?.type === 'ArrayExpression') {
-            if (itemsCountStack[itemsCountStack.length - 1] !== 0) {
-              pathStack.pop()
-              if (!skipStack.pop()) {
-                generator.pushline(`,`)
-              }
-            }
-          }
-          break
-        case 'Property':
-          if (parent?.type === 'ObjectExpression') {
-            if (propsCountStack[propsCountStack.length - 1] !== 0) {
-              pathStack.pop()
-              if (!skipStack.pop()) {
-                generator.pushline(`,`)
-              }
-            }
-          }
+          generator.push('}')
           break
         case 'ArrayExpression':
           if (itemsCountStack[itemsCountStack.length - 1] === 0) {
@@ -480,29 +418,22 @@ function _generate(
             itemsCountStack.pop()
           }
           generator.deindent()
-          generator.push(`]`)
-          if (parent?.type === 'ArrayExpression') {
-            if (itemsCountStack[itemsCountStack.length - 1] !== 0) {
-              pathStack.pop()
-              if (!skipStack.pop()) {
-                generator.pushline(`,`)
-              }
-            }
-          }
-          break
-        case 'Literal':
-          if (parent?.type === 'ArrayExpression') {
-            if (itemsCountStack[itemsCountStack.length - 1] !== 0) {
-              pathStack.pop()
-            }
-
-            if (!skipStack.pop()) {
-              generator.pushline(`,`)
-            }
-          }
+          generator.push(']')
           break
         default:
           break
+      }
+
+      if (
+        parent?.type === 'ArrayExpression' ||
+        parent?.type === 'ObjectExpression'
+      ) {
+        const stackArr =
+          node.type === 'Property' ? propsCountStack : itemsCountStack
+        if (stackArr[stackArr.length - 1] !== 0) {
+          pathStack.pop()
+          !skipStack.pop() && generator.pushline(',')
+        }
       }
     }
   })

--- a/packages/bundle-utils/test/generator/__snapshots__/js.test.ts.snap
+++ b/packages/bundle-utils/test/generator/__snapshots__/js.test.ts.snap
@@ -214,12 +214,10 @@ exports[`array basic > code 1`] = `
     "resource": {
       "foo": [
         [
-          (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["bar"])};fn.source="bar";return fn;})(),
-          
+          (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["bar"])};fn.source="bar";return fn;})()
         ],
         [
-          (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["baz"])};fn.source="baz";return fn;})(),
-          
+          (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["baz"])};fn.source="baz";return fn;})()
         ]
       ]
     }
@@ -254,14 +252,12 @@ exports[`array mixed > code 1`] = `
             {
               "foo": (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["foo"])};fn.source="foo";return fn;})()
             },
-            (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["hoge"])};fn.source="hoge";return fn;})(),
-            
+            (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["hoge"])};fn.source="hoge";return fn;})()
           ]
         ],
         (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["baz"])};fn.source="baz";return fn;})(),
         [
-          (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["buz"])};fn.source="buz";return fn;})(),
-          
+          (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["buz"])};fn.source="buz";return fn;})()
         ]
       ]
     }
@@ -315,8 +311,7 @@ const resource = {
   "backslash-backslash": (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["\\\\\\\\"])};fn.source="\\\\\\\\";return fn;})(),
   "errors": [
     (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["ERROR1001"])};fn.source="ERROR1001";return fn;})(),
-    (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["ERROR1002"])};fn.source="ERROR1002";return fn;})(),
-    
+    (()=>{const fn=(ctx) => {const { normalize: _normalize } = ctx;return _normalize(["ERROR1002"])};fn.source="ERROR1002";return fn;})()
   ],
   "complex": {
     "warnings": [


### PR DESCRIPTION
This refactor removes and reuses repeated patterns in the generate function, some aspects I still don't fully understand (for example the function of `pathStack`). But this refactor helped me see which logic is essential per node type.

The snapshots have been updated since this also removes the trailing comma from the last item in arrays, in the same way we already did for last property/value in objects.