### PR TITLE
chore: renovate ignore unmaintained projects

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "labels": ["Type: Dependency"],
   "automerge": true,
   "ignoreDeps": ["playwright", "husky", "source-map"],
+  "ignorePaths": ["**/node_modules/**", "**/.unmaintained/**"],
   "major": {
     "automerge": false
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I noticed the renovate bot still opens PRs to update dependencies in the `.unmaintained/**` projects, this should ignore these paths and reduce noise on the repo and discord notification channel.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
