### PR TITLE
fix(unpluing-vue-i18n): Support for `transform.handler` in vite:json plugin

### DIFF
--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -14,7 +14,16 @@ import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import { dirname, parse as parsePath, resolve } from 'node:path'
 import { parse } from 'vue/compiler-sfc'
-import { checkVuePlugin, error, getVitePlugin, raiseError, resolveNamespace, warn } from '../utils'
+import {
+  checkVuePlugin,
+  error,
+  getVitePlugin,
+  getVitePluginTransform,
+  overrideVitePluginTransform,
+  raiseError,
+  resolveNamespace,
+  warn
+} from '../utils'
 import { getVueCompiler, parseVueRequest } from '../vue'
 
 import type { CodeGenOptions } from '@intlify/bundle-utils'
@@ -168,12 +177,23 @@ export function resourcePlugin(opts: ResolvedOptions, meta: UnpluginContextMeta)
         ctx.sourceMap = config.command === 'build' ? !!config.build.sourcemap : false
         debug(`configResolved: isProduction = ${ctx.prod}, sourceMap = ${ctx.sourceMap}`)
 
+        /**
+         * NOTE:
+         * For the native rolldown plugin, we need to change to another solution from the current workaround.
+         * Currently, the rolldown team and vite team are discussing this issue.
+         * https://github.com/vitejs/rolldown-vite/issues/120
+         */
+
         // json transform handling
         const jsonPlugin = getVitePlugin(config, 'vite:json')
         if (jsonPlugin) {
-          // backup @rollup/plugin-json
-          const orgTransform = jsonPlugin.transform
-          jsonPlugin.transform = async function (code: string, id: string) {
+          // saving `vite:json` plugin instance
+          const [orgTransform, transformWay] = getVitePluginTransform(jsonPlugin)
+          if (!orgTransform) {
+            throw new Error('vite:json plugin not found!')
+          }
+
+          async function overrideViteJsonPlugin(code: string, id: string) {
             if (!/\.json$/.test(id) || filter(id)) {
               return
             }
@@ -195,6 +215,9 @@ export function resourcePlugin(opts: ResolvedOptions, meta: UnpluginContextMeta)
             // @ts-expect-error
             return orgTransform!.apply(this, [code, id])
           }
+
+          // override `vite:json` plugin transform function
+          overrideVitePluginTransform(jsonPlugin, overrideViteJsonPlugin, transformWay!)
         }
       }
     },

--- a/packages/unplugin-vue-i18n/src/utils/plugin.ts
+++ b/packages/unplugin-vue-i18n/src/utils/plugin.ts
@@ -15,6 +15,34 @@ export function getVitePlugin(config: UserConfig, name: string): RollupPlugin | 
   return config.plugins.find(p => p.name === name) as RollupPlugin
 }
 
+export function getVitePluginTransform(
+  plugin: RollupPlugin
+): [RollupPlugin['transform'], 'handler' | 'transform' | undefined] {
+  if (plugin.transform) {
+    return 'handler' in plugin.transform
+      ? [plugin.transform.handler, 'handler']
+      : [plugin.transform, 'transform']
+  } else {
+    return [undefined, undefined]
+  }
+}
+
+// TODO: `override` type, we need more strict type
+export function overrideVitePluginTransform(
+  plugin: RollupPlugin,
+  override: Function,
+  to: 'handler' | 'transform'
+): void {
+  if (plugin.transform == undefined) {
+    throw new Error('plugin.transform is undefined')
+  }
+  if (to === 'handler' && 'handler' in plugin.transform) {
+    plugin.transform.handler = override as typeof plugin.transform.handler
+  } else {
+    plugin.transform = override as typeof plugin.transform
+  }
+}
+
 export function checkVuePlugin(vuePlugin: RollupPlugin | null): boolean {
   if (vuePlugin == null || !vuePlugin.api) {
     error(


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In vite 6.3, the handling of plugin hooks has been changed from transform to transform.handler internally.
Currently, vite is minimizing the impact on end users through a patch, but in vite 7, the patch for transform will be removed.

### Linked Issues

- #483

### Additional context

Rollup used internally in Vite will be replaced by Rolldown in the future. Rolldown plans to provide JSON transform plugin natively, but the current workaround that hijacks the unplugin-vue-i18n Vite JSON plugin cannot be used.
Regarding this issue, the Rolldown team and Vite team are currently discussing a workaround mechanism at the following URL. 

https://github.com/vitejs/rolldown-vite/issues/120

<!-- e.g. is there anything you'd like reviewers to focus on? -->
