### PR TITLE
fix: normalize include exclude paths

### DIFF
--- a/packages/unplugin-vue-i18n/src/core/options.ts
+++ b/packages/unplugin-vue-i18n/src/core/options.ts
@@ -1,7 +1,13 @@
-import { isString, isBoolean, isArray } from '@intlify/shared'
+import { isArray, isBoolean, isString } from '@intlify/shared'
+import { normalize } from 'pathe'
 
 import type { PluginOptions } from '../types'
 import type { TranslationDirectiveResolveIndetifier } from '../vue'
+
+function normalizeGlobOption(val: string | string[] | undefined) {
+  if (!val) return undefined
+  return isString(val) ? [normalize(val)] : val.map(normalize)
+}
 
 export function resolveOptions(options: PluginOptions) {
   const moduleType = (options.module || 'vue-i18n') as string
@@ -53,8 +59,8 @@ export function resolveOptions(options: PluginOptions) {
     typeof options.transformI18nBlock === 'function' ? options.transformI18nBlock : null
 
   return {
-    include: options.include,
-    exclude: options.exclude,
+    include: normalizeGlobOption(options.include),
+    exclude: normalizeGlobOption(options.exclude),
     module: moduleType,
     onlyLocales,
     forceStringify,

--- a/packages/unplugin-vue-i18n/src/core/resource.ts
+++ b/packages/unplugin-vue-i18n/src/core/resource.ts
@@ -4,20 +4,12 @@ import {
   generateTypescript,
   generateYAML
 } from '@intlify/bundle-utils'
-import {
-  assign,
-  generateCodeFrame,
-  isArray,
-  isEmptyObject,
-  isNumber,
-  isString
-} from '@intlify/shared'
+import { assign, generateCodeFrame, isEmptyObject, isNumber, isString } from '@intlify/shared'
 import { createFilter } from '@rollup/pluginutils'
 import createDebug from 'debug'
 import fg from 'fast-glob'
 import { promises as fs } from 'node:fs'
 import { parse as parsePath } from 'node:path'
-import { normalize } from 'pathe'
 import { parse } from 'vue/compiler-sfc'
 import { checkVuePlugin, error, getVitePlugin, raiseError, resolveNamespace, warn } from '../utils'
 import { getVueCompiler, parseVueRequest } from '../vue'
@@ -83,30 +75,18 @@ export function resourcePlugin(
   function resolveIncludeExclude() {
     const customBlockInclude =
       meta.framework === 'vite' ? RE_SFC_I18N_CUSTOM_BLOCK : RE_SFC_I18N_WEBPACK_CUSTOM_BLOCK
-    if (isArray(include)) {
-      return [[...include, customBlockInclude], exclude]
-    } else if (isString(include)) {
-      return [[include, customBlockInclude], exclude]
-    } else {
-      return [[RE_RESOURCE_FORMAT, customBlockInclude], exclude]
-    }
+    return include
+      ? [[...include, customBlockInclude], exclude]
+      : [[RE_RESOURCE_FORMAT, customBlockInclude], exclude]
   }
 
   function resolveIncludeExcludeForLegacy() {
     const customBlockInclude =
       meta.framework === 'vite' ? RE_SFC_I18N_CUSTOM_BLOCK : RE_SFC_I18N_WEBPACK_CUSTOM_BLOCK
-    let _include: string | (string | RegExp)[] | undefined = undefined
-    let _exclude: string | (string | RegExp)[] | undefined = undefined
-    if (include) {
-      if (isArray(include)) {
-        _include = [...include.map(item => normalize(item)), customBlockInclude]
-      } else if (isString(include)) {
-        _include = [normalize(include), customBlockInclude]
-      }
-    } else {
-      _exclude = '**/**'
-    }
-    return [_include, _exclude]
+    // prettier-ignore
+    return include
+      ? [[...include, customBlockInclude], undefined]
+      : [undefined, ['**/**']]
   }
 
   let _filter: ReturnType<typeof createFilter> | null = null
@@ -337,8 +317,7 @@ export function resourcePlugin(
         debug('load', id)
         if (INTLIFY_BUNDLE_IMPORT_ID === getVirtualId(id, meta.framework) && include) {
           let resourcePaths = [] as string[]
-          const includePaths = isArray(include) ? include : [include]
-          for (const inc of includePaths) {
+          for (const inc of include) {
             resourcePaths = [...resourcePaths, ...(await fg(inc))]
           }
           resourcePaths = resourcePaths.filter((el, pos) => resourcePaths.indexOf(el) === pos)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/gunshi/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This fixes a regression, the `include` and `exclude` options were not always normalized which breaks paths using forward slashes. This PR now normalizes these path options inside `resolveOptions`, and further normalizes them from `string | string[] | undefined` to `string[] | undefined` which allows us to remove some repeated logic.

Possible covers #501, though it is unclear since the issue creator did not provide a reproduction project
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
